### PR TITLE
Add dstack to Privacy by Design section

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ The General Data Protection Regulation (GDPR) is a regulation on data protection
 * [Norwegian DPA - Software development with Data Protection by Design and by Default](https://www.datatilsynet.no/en/about-privacy/virksomhetenes-plikter/data-protection-by-design-and-by-default/)
 * [Data Pseudonymisation: Advanced Techniques and Use Cases](https://www.enisa.europa.eu/publications/data-pseudonymisation-advanced-techniques-and-use-cases/) - Report on pseudonymisation techniques from ENISA.
 * [Anonymisation, pseudonymisation and privacy enhancing technologies guidance - ICO](https://ico.org.uk/about-the-ico/ico-and-stakeholder-consultations/ico-call-for-views-anonymisation-pseudonymisation-and-privacy-enhancing-technologies-guidance/)
+* [dstack](https://github.com/Dstack-TEE/dstack) - Open-source confidential computing framework enabling privacy by design through hardware-enforced isolation for GDPR-compliant data processing.
 
 ## Records of Processing (art. 30)
 * [Iubenda - Register of data processing activities](https://www.iubenda.com/en/internal-privacy-management)


### PR DESCRIPTION
## Summary
Added dstack to the "Privacy by Design - Guides for developers (art. 25)" section as an open-source confidential computing framework that enables privacy by design principles.

## Why include dstack
dstack helps developers implement GDPR Article 25 requirements by providing hardware-enforced isolation for data processing, enabling privacy by design and by default. It complements existing privacy enhancing technologies in the list by offering a practical framework for confidential computing.