### PR TITLE
Add dcm-anon and ehds-anon-kit under Privacy by Design (art. 25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ The General Data Protection Regulation (GDPR) is a regulation on data protection
 * [Data Pseudonymisation: Advanced Techniques and Use Cases](https://www.enisa.europa.eu/publications/data-pseudonymisation-advanced-techniques-and-use-cases/) - Report on pseudonymisation techniques from ENISA.
 * [Anonymisation, pseudonymisation and privacy enhancing technologies guidance - ICO](https://ico.org.uk/about-the-ico/ico-and-stakeholder-consultations/ico-call-for-views-anonymisation-pseudonymisation-and-privacy-enhancing-technologies-guidance/)
 * [dstack](https://github.com/Dstack-TEE/dstack) - Open-source confidential computing framework enabling privacy by design through hardware-enforced isolation for GDPR-compliant data processing.
+* [dcm-anon](https://github.com/Ces107/dcm-anon) - DICOM PS3.15 Basic Profile anonymizer with a verbatim-cited GDPR Article 35 / Article 9 compliance manifest. Pseudonymous-output labelling per Art. 4(5) addresses the CNIL/Cegedim Sante 2024 pattern.
+* [ehds-anon-kit](https://github.com/plusultra-tools/ehds-anon-kit) - EHDS secondary-use de-identification kit for Health Data Access Bodies; reuses the verbatim-citation manifest pattern from dcm-anon.
 
 ## Records of Processing (art. 30)
 * [Iubenda - Register of data processing activities](https://www.iubenda.com/en/internal-privacy-management)


### PR DESCRIPTION
Adds two MIT-licensed OSS tools that implement the technical step of pseudonymisation alongside the documentation step a controller has to demonstrate under GDPR Art. 25 and Art. 35.

- dcm-anon: DICOM PS3.15 Basic Profile anonymizer. Output is explicitly labelled pseudonymous per Art. 4(5). Manifest carries an Art. 9(2) lawful-basis disclosure, addressing the CNIL/Cegedim Sante decision SAN-2024-013 pattern (EUR 800,000 fine, September 2024) where the technical pseudonymisation was correct but the upstream Art. 9 lawful basis had not been established.
- ehds-anon-kit: EHDS secondary-use de-identification kit for Health Data Access Bodies. Reuses the verbatim-citation manifest pattern from dcm-anon.

Both repos pushed within the last week, MIT, pip-installable. Disclosure: I am the author. Added under Privacy by Design (art. 25). If you prefer them in the DPIA (art. 35) section, happy to move them.