### PR TITLE
Add TrustYourWebsite to Tools section

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ The General Data Protection Regulation (GDPR) is a regulation on data protection
 * [Data protection around the world](https://www.cnil.fr/en/data-protection-around-the-world) - (CNIL) Map of the level of data protection in each country. 
 * [Data Protection Laws of the world](https://www.dlapiperdataprotection.com/) - (DLA Piper) Compare data protection laws around the world.
 * [Comparison of Consent Management Platforms](https://github.com/JermainKroot/best-consent-management-platforms) - Hands-on comparison of 9 platforms.
+* [TrustYourWebsite](https://trustyourwebsite.com) - Automated GDPR, cookie and accessibility compliance scanner for EU small-business websites; free scan returns a risk score and issue counts.
 
 ## Data Protection Authorities (art. 51 -59)
 * [European Data Protection Board](https://edpb.europa.eu/) - EDPB.


### PR DESCRIPTION
Adds TrustYourWebsite, an automated compliance scanner (GDPR, cookie banners, accessibility, legal pages) aimed at EU small businesses. The free tier scans any site and returns a risk score with issue counts; paid reports add full findings.

Comparable in scope to the EDPS Website Evidence Collector already listed, but aimed at small-business owners rather than regulators.

Disclosure: I'm the author. Happy to adjust wording or placement.